### PR TITLE
Refine PowerShell encoding logic to handle missing `oemcp` value and …

### DIFF
--- a/src/wslu-header
+++ b/src/wslu-header
@@ -237,7 +237,7 @@ function sysdrive_prefix {
 				win_location="${pt##*/}"
 				break
 			fi
-		fi 
+		fi
 	done
 
 	if [ $hard_reset -eq 0 ]; then
@@ -285,16 +285,21 @@ function winps_exec {
 	debug_echo "winps_exec: called with command $*"
 	if [[ "$WSLU_POWERSHELL_CHCP_WORKAROUND" == "true" ]]; then
 		wslutmpbuild="$(wslu_get_build)"
-		cp="$(cat "${wslu_state_dir}"/oemcp)"
-		[ "$wslutmpbuild" -ge $BN_OCT_NINETEEN ] || chcp_com "$cp"
+		local cp="$(cat "${wslu_state_dir}"/oemcp)"
+    if [[ -z "$cp" ]]; then
+      var_gen
+      cp="$(cat "${wslu_state_dir}"/oemcp)"
+    fi
+
+		[ "$wslutmpbuild" -ge "$BN_OCT_NINETEEN" ] || chcp_com "$cp"
 		"$(interop_prefix)$(sysdrive_prefix)"/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::GetEncoding($cp); $*"
 		EXIT_STATUS=$?
-		[ "$wslutmpbuild" -ge $BN_OCT_NINETEEN ] || chcp_com 65001
-		return $EXIT_STATUS
+		[ "$wslutmpbuild" -ge "$BN_OCT_NINETEEN" ] || chcp_com 65001
+		return "$EXIT_STATUS"
 	else
 		"$(interop_prefix)$(sysdrive_prefix)"/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$*"
 		EXIT_STATUS=$?
-		return $EXIT_STATUS
+		return "$EXIT_STATUS"
 	fi
 }
 


### PR DESCRIPTION
This pull request makes improvements to the `winps_exec` function in `src/wslu-header`, focusing on more robust handling of the code page value and consistency in variable usage. The main changes ensure that the code page (`cp`) is always set before use, and that return values are quoted for safety.

Enhancements to code page handling and consistency:

* Added a check to ensure the `cp` variable is set; if not, it calls `var_gen` to generate it before proceeding.
* Quoted all usages of `cp` and `EXIT_STATUS` to prevent issues with variable expansion and to improve script robustness.
* Updated numeric comparison to quote `BN_OCT_NINETEEN` for consistency and to avoid potential bugs.